### PR TITLE
Changes to npc_bec's death sound

### DIFF
--- a/sp/src/game/server/ezu/npc_bec.cpp
+++ b/sp/src/game/server/ezu/npc_bec.cpp
@@ -296,7 +296,7 @@ void CNPC_Bec::DeathSound( const CTakeDamageInfo &info )
 	// Sentences don't play on dead NPCs
 	SentenceStop();
 
-	EmitSound( "bec.die" );
+	SpeakIfAllowed( TLK_DEATH );
 
 }
 


### PR DESCRIPTION
npc_bec's death sound used to be the "bec.die" soundscript sound instead of the response TLK_DEATH. This meant that npc_bec with a response system override (such as Bloody Cop) were not able to have their own death sounds and would instead use Bec's death sound. This pull request aims to resolve the issue.