### PR TITLE
Fixed npc_bec's death sound (for real this time?)

### DIFF
--- a/sp/src/game/server/ezu/npc_bec.cpp
+++ b/sp/src/game/server/ezu/npc_bec.cpp
@@ -296,7 +296,7 @@ void CNPC_Bec::DeathSound( const CTakeDamageInfo &info )
 	// Sentences don't play on dead NPCs
 	SentenceStop();
 
-	SpeakIfAllowed( TLK_DEATH );
+	Speak( TLK_DEATH );
 
 }
 


### PR DESCRIPTION
I messed up here. In my previous fix, I used "SpeakIfAllowed" instead of just "Speak". When an NPC dies, they're not allowed to speak anymore, so it should use "Speak" (without the "ifallowed"). This change is important so that both Bloody Cop and Bec can have unique death sounds defined by the response system.