### PR TITLE
Separate NPC and player spread for AR2

### DIFF
--- a/sp/src/game/server/hl2/weapon_ar2.cpp
+++ b/sp/src/game/server/hl2/weapon_ar2.cpp
@@ -565,7 +565,7 @@ void CWeaponAR2::FireNPCPrimaryAttack(CBaseCombatCharacter* pOperator, Vector& v
 	CSoundEnt::InsertSound(SOUND_COMBAT | SOUND_CONTEXT_GUNFIRE, pOperator->GetAbsOrigin(), SOUNDENT_VOLUME_MACHINEGUN, 0.2, pOperator, SOUNDENT_CHANNEL_WEAPON, pOperator->GetEnemy());
 	pOperator->FireBullets(1, vecShootOrigin, vecShootDir, GetBulletSpread(), MAX_TRACE_LENGTH, m_iPrimaryAmmoType, 2, entindex(), 0);
 	pOperator->DoMuzzleFlash(); // Changing the shots doesn't help - just blows us up !
-	m_flSpreadComponent += (MAX_SPREAD_COMPONENT - MIN_SPREAD_COMPONENT) * 0.33f; // 1/3 The difference between max and min
+	m_flSpreadComponent += (MAX_NPC_SPREAD_COMPONENT - MIN_NPC_SPREAD_COMPONENT) * 0.33f; // 1/3 The difference between max and min E8: Changed to use special NPC variable
 
 	m_iClip1 = m_iClip1 - 1;
 }

--- a/sp/src/game/server/hl2/weapon_ar2.h
+++ b/sp/src/game/server/hl2/weapon_ar2.h
@@ -32,6 +32,10 @@ public:
 	#define MAX_SPREAD_COMPONENT 0.03490 // Was 0.25881
 										 // Default is: 0.34202
 
+	#define MIN_NPC_SPREAD_COMPONENT 0.13053 // Employee8: We don't want NPCs to be as accurate as the player!
+
+	#define MAX_NPC_SPREAD_COMPONENT 0.34202
+
 	void	ItemPostFrame( void );
 	void	Precache( void );
 


### PR DESCRIPTION
This patch adds a variable for NPC spread. This will hopefully resolve our issues with overly accurate NPCs.